### PR TITLE
Change CountBenchQA Dataset Link

### DIFF
--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -2277,11 +2277,12 @@ class TDBenchGrounding(ImageVQADataset):
 
 
 class CountBenchQA(ImageVQADataset):
+    TYPE = "VQA"
     DATASET_URL = {
-        'CountBenchQA':
-        'https://opencompass.openxlab.space/utils/VLMEval/CountBenchQA.tsv'
+        "CountBenchQA": 
+        "https://huggingface.co/datasets/moondream/CountBenchQA-VLMEvalKit/resolve/main/countbench_data.tsv"
     }
-    DATASET_MD5 = {'CountBenchQA': 'f4f65f3fe57f0fd30ca67a3baae16b9d'}
+    DATASET_MD5 = {"CountBenchQA": "d70123bd9d7c090b00101f2116f3a7c6"}
 
     def build_prompt(self, line):
         if isinstance(line, int):
@@ -2297,7 +2298,7 @@ class CountBenchQA(ImageVQADataset):
     def evaluate(self, eval_file, **judge_kwargs):
         data = load(eval_file).sort_values(by='index')
         predictions = [str(x) for x in data['prediction']]
-        answers = [str(x) for x in data['answers']]
+        answers = [str(x) for x in data['answer']]
         correct_count = 0
         total_count = len(predictions)
 


### PR DESCRIPTION
The previous CountBenchQA had various bad examples (example 162, 262, and 371) which are now removed in this updated link.

